### PR TITLE
Fix various issues

### DIFF
--- a/cmd/spiffe-aws-assume-role/cli/cli.go
+++ b/cmd/spiffe-aws-assume-role/cli/cli.go
@@ -12,7 +12,7 @@ import (
 type CredentialsCmd struct {
 	Audience       string `required:"" help:"SVID JWT Audience. Must match AWS configuration"`
 	SpiffeID       string `required:"" help:"The SPIFFE ID of this workload"`
-	WorkloadSocket string `optional:"" help:"Path to SPIFFE Workload Socket" type:"existingfile"`
+	WorkloadSocket string `optional:"" help:"Path to SPIFFE Workload Socket"`
 	RoleARN        string `required:"" help:"AWS Role ARN to assume"`
 	SessionName    string `optional:"" help:"AWS Session Name"`
 	STSEndpoint    string `optional:"" help:"AWS STS Endpoint variable"`
@@ -26,7 +26,7 @@ func (c *CredentialsCmd) Run() error {
 
 	src := credentials.NewJWTSVIDSource(spiffeID, c.WorkloadSocket, c.Audience)
 
-	provider, err := credentials.NewProvider(c.Audience, src)
+	provider, err := credentials.NewProvider(c.Audience, c.RoleARN, src)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (c *CredentialsCmd) Run() error {
 		return err
 	}
 
-	_, err = fmt.Print(creds)
+	_, err = fmt.Print(string(creds))
 	return err
 }
 

--- a/pkg/credentials/spiffejwt.go
+++ b/pkg/credentials/spiffejwt.go
@@ -3,10 +3,15 @@ package credentials
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+const (
+	workloadConnTimeout = 3 * time.Second
 )
 
 type JWTSVIDSource struct {
@@ -29,6 +34,9 @@ func (jss *JWTSVIDSource) FetchToken(ctx context.Context) (string, error) {
 	if jss.workloadSocket != "" {
 		dialOpts = append(dialOpts, workloadapi.WithClientOptions(workloadapi.WithAddr(jss.workloadSocket)))
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, workloadConnTimeout)
+	defer cancel()
 
 	jwtSource, err := workloadapi.NewJWTSource(ctx, dialOpts...)
 	if err != nil {


### PR DESCRIPTION
Some issues I ran into:
- 'existingfile' stanza modified WorkloadSocket such that it didn't
  start with 'unix:///'
- RoleARN wasn't being passed to STS
- There's a difference between empty Policy and no Policy present, from
  the STS API perspective
- credentials provider requires AWS Session to be initialized
- RoleSessionName cannot have whitespace