### PR TITLE
Removing pull_request trigger to prevent duplicate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [pull_request, push]
+on: [push]
 jobs:
   job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every push to a PR branch is both a push and pull_request event