### PR TITLE
Making Parse public, adding helper method to create default CliContext

### DIFF
--- a/cmd/spiffe-aws-assume-role/cli/cli.go
+++ b/cmd/spiffe-aws-assume-role/cli/cli.go
@@ -4,13 +4,8 @@ import (
 	"fmt"
 
 	"github.com/alecthomas/kong"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/square/spiffe-aws-assume-role/cmd/spiffe-aws-assume-role/cli/mappers"
-	"github.com/square/spiffe-aws-assume-role/pkg/credentials"
-	"github.com/square/spiffe-aws-assume-role/pkg/telemetry"
 )
 
 type CLI struct {
@@ -18,21 +13,9 @@ type CLI struct {
 }
 
 func RunWithDefaultContext(args []string) error {
-	logger := logrus.New()
-	// Example log line:
-	// time="2021-03-01T16:28:51-08:00" level=error msg="failed to parse SPIFFE ID from 305d07ed-765e-4642-9bd3-4c74aa86f5ed: spiffeid: invalid scheme"
-	logger.SetFormatter(&logrus.TextFormatter{})
-
-	telemetry, err := telemetry.NullTelemetry()
+	context, err := NewDefaultCliContext()
 	if err != nil {
 		return err
-	}
-
-	context := &CliContext{
-		JWTSourceProvider: credentials.StandardJWTSourceProvider,
-		STSProvider:       credentials.StandardSTSProvider,
-		Logger:            logger,
-		Telemetry:         telemetry,
 	}
 
 	return Run(context, args)
@@ -45,7 +28,7 @@ func Run(context *CliContext, args []string) (err error) {
 		}
 	}()
 
-	ctx, err := parse(args)
+	ctx, err := Parse(args)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to parse command line arguments: %s", args))
 	}
@@ -59,25 +42,11 @@ func newKong(cli *CLI) (*kong.Kong, error) {
 	return kong.New(cli, kong.NamedMapper(mappers.Iso8601DurationMapperType, mappers.Iso8601DurationMapper{}))
 }
 
-func parse(args []string) (*kong.Context, error) {
+func Parse(args []string) (*kong.Context, error) {
 	parser, err := newKong(&CLI{})
 	if err != nil {
 		return nil, err
 	}
 
 	return parser.Parse(args)
-}
-
-func createSession(stsEndpoint string, stsRegion string) *session.Session {
-	config := &aws.Config{}
-
-	if len(stsEndpoint) > 0 {
-		config.Endpoint = aws.String(stsEndpoint)
-	}
-
-	if len(stsRegion) > 0 {
-		config.Region = aws.String(stsRegion)
-	}
-
-	return session.Must(session.NewSession(config))
 }

--- a/cmd/spiffe-aws-assume-role/cli/cli_context.go
+++ b/cmd/spiffe-aws-assume-role/cli/cli_context.go
@@ -12,3 +12,24 @@ type CliContext struct {
 	Logger            *logrus.Logger
 	Telemetry         *telemetry.Telemetry
 }
+
+func NewDefaultCliContext() (*CliContext, error) {
+	logger := logrus.New()
+	// Example log line:
+	// time="2021-03-01T16:28:51-08:00" level=error msg="failed to parse SPIFFE ID from 305d07ed-765e-4642-9bd3-4c74aa86f5ed: spiffeid: invalid scheme"
+	logger.SetFormatter(&logrus.TextFormatter{})
+
+	telemetry, err := telemetry.NullTelemetry()
+	if err != nil {
+		return nil, err
+	}
+
+	context := &CliContext{
+		JWTSourceProvider: credentials.StandardJWTSourceProvider,
+		STSProvider:       credentials.StandardSTSProvider,
+		Logger:            logger,
+		Telemetry:         telemetry,
+	}
+
+	return context, nil
+}

--- a/cmd/spiffe-aws-assume-role/cli/cli_test.go
+++ b/cmd/spiffe-aws-assume-role/cli/cli_test.go
@@ -77,7 +77,7 @@ func TestParsesLogFilePath(t *testing.T) {
 func parseTest(t *testing.T, arg string) CredentialsCmd {
 	args := append(requiredArgs, arg)
 
-	context, err := parse(args)
+	context, err := Parse(args)
 	require.NoError(t, err)
 
 	cli := context.Model.Target.Interface().(CLI)
@@ -95,7 +95,7 @@ func TestParsesStsRegion(t *testing.T) {
 		"--role-arn=bar",
 		"--spiffe-id=baz",
 	}
-	context, err := parse(args)
+	context, err := Parse(args)
 	require.NoError(t, err)
 
 	cli := context.Model.Target.Interface().(CLI)

--- a/cmd/spiffe-aws-assume-role/cli/credentials_cmd.go
+++ b/cmd/spiffe-aws-assume-role/cli/credentials_cmd.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -87,4 +89,18 @@ func (c *CredentialsCmd) configureTelemetry() (t *telemetry.Telemetry, err error
 		t.AddLabel("stsRegion", c.STSRegion)
 	}
 	return
+}
+
+func createSession(stsEndpoint string, stsRegion string) *session.Session {
+	config := &aws.Config{}
+
+	if len(stsEndpoint) > 0 {
+		config.Endpoint = aws.String(stsEndpoint)
+	}
+
+	if len(stsRegion) > 0 {
+		config.Region = aws.String(stsRegion)
+	}
+
+	return session.Must(session.NewSession(config))
 }


### PR DESCRIPTION
Supporting changes to allow calling code to inspect and modify parsed context before execution