### PR TITLE
hook up CLI session name option to provider

### DIFF
--- a/cmd/spiffe-aws-assume-role/cli/credentials_cmd.go
+++ b/cmd/spiffe-aws-assume-role/cli/credentials_cmd.go
@@ -57,6 +57,7 @@ func (c *CredentialsCmd) Run(context *CliContext) (err error) {
 		c.Audience,
 		c.RoleARN,
 		src,
+		c.SessionName,
 		c.SessionDuration,
 		stsClient,
 		t,

--- a/pkg/credentials/provider.go
+++ b/pkg/credentials/provider.go
@@ -20,6 +20,7 @@ func NewProvider(
 	audience string,
 	roleARN string,
 	jwtSource JWTSource,
+	sessionName string,
 	sessionDuration time.Duration,
 	stsClient stsiface.STSAPI,
 	telemetry *telemetry.Telemetry,
@@ -34,6 +35,7 @@ func NewProvider(
 		RenewWindow:     time.Minute, // Default to 1 minute pre-renew. This avoids in-flight requests expiring.
 		jwtSource:       jwtSource,
 		SessionDuration: sessionDuration,
+		SessionName:     sessionName,
 		telemetry:       telemetry,
 		logger:          logger,
 	}

--- a/pkg/credentials/provider_test.go
+++ b/pkg/credentials/provider_test.go
@@ -122,6 +122,7 @@ func TestPassesSessionDurationToStsAssumeRole(t *testing.T) {
 
 func TestNewProviderAssignsSessionDuration(t *testing.T) {
 	nonZeroSessionDuration := time.Duration(randomInt32(1023) + 1)
+	sessionName := "testSession"
 
 	var audience, roleArn string
 	var jwtSource JWTSource
@@ -130,6 +131,7 @@ func TestNewProviderAssignsSessionDuration(t *testing.T) {
 		audience,
 		roleArn,
 		jwtSource,
+		sessionName,
 		nonZeroSessionDuration,
 		nil,
 		telemetry.MustNullTelemetry(),
@@ -168,10 +170,13 @@ func TestRetrieveSetsExpirationOnCredentials(t *testing.T) {
 		On("AssumeRoleWithWebIdentityWithContext", mock.Anything, mock.Anything).
 		Return(&assumeRoleResponse, nil)
 
+	sessionName := "testSession"
+
 	provider, err := NewProvider(
 		audience,
 		roleArn,
 		&jwtSource,
+		sessionName,
 		sessionDuration,
 		&stsClient,
 		telemetry.MustNullTelemetry(),


### PR DESCRIPTION
allow session name for assuming a role to be configurable