### PR TITLE
fix bug with workload conn

### DIFF
--- a/pkg/credentials/spiffejwt.go
+++ b/pkg/credentials/spiffejwt.go
@@ -65,6 +65,7 @@ func (jss *JWTSVIDSource) FetchToken(ctx context.Context) (token string, err err
 	if err != nil {
 		return "", errors.Wrap(err, "creating JWT-SVID source")
 	}
+	defer jwtSource.Close()
 
 	params := jwtsvid.Params{
 		Audience: jss.audience,


### PR DESCRIPTION
we need to close the `jwtSource` when we're done with it
