### PR TITLE
fix(rolesanywhere): Throw error on nil deref after failed creds

### DIFF
--- a/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
+++ b/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
@@ -49,6 +49,7 @@ type RolesAnywhereCmd struct {
 	TelemetryServiceAsLabel bool          `optional:"" group:"Telemetry" help:"Place the Service name as a label instead of prefix"`
 	SentryDSN               string        `optional:"" group:"Process Config" help:"DSN from Sentry for sending errors (e.g.  https://<hash>@o123456.ingest.sentry.io/123456"`
 	Debug                   bool          `optional:"" group:"Process Config" help:"Enable debug logging"`
+	IgnoreIntermediates     bool          `optional:"" group:"Process Config" help:"Ignore bundled certificate intermediates"`
 }
 
 type rolesAnywhereSignerData struct {
@@ -244,8 +245,12 @@ func (c *RolesAnywhereCmd) extractCertificateData() (*rolesAnywhereSignerData, e
 	// Collect certificate and any intermediates
 	certificate := certificateChain[0]
 	var intermediates []x509.Certificate
-	if len(certificateChain) > 1 {
-		intermediates = certificateChain[1:]
+	if c.IgnoreIntermediates {
+		intermediates = nil
+	} else {
+		if len(certificateChain) > 1 {
+			intermediates = certificateChain[1:]
+		}
 	}
 
 	//extract key type

--- a/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
+++ b/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
@@ -142,6 +142,9 @@ func (c *RolesAnywhereCmd) RunRolesAnywhere(context *CliContext, telemetry *tele
 
 	// Get RolesAnywhere Creds
 	output, err := c.createRolesAnywhereCreds(createRolesAnywhereCredsInput)
+	if err != nil {
+		return err
+	}
 
 	// Use the RolesAnywhere Creds to jump to other account's role
 	if requireJump {

--- a/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
+++ b/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
@@ -49,7 +49,6 @@ type RolesAnywhereCmd struct {
 	TelemetryServiceAsLabel bool          `optional:"" group:"Telemetry" help:"Place the Service name as a label instead of prefix"`
 	SentryDSN               string        `optional:"" group:"Process Config" help:"DSN from Sentry for sending errors (e.g.  https://<hash>@o123456.ingest.sentry.io/123456"`
 	Debug                   bool          `optional:"" group:"Process Config" help:"Enable debug logging"`
-	IgnoreIntermediates     bool          `optional:"" group:"Process Config" help:"Ignore bundled certificate intermediates"`
 }
 
 type rolesAnywhereSignerData struct {
@@ -245,12 +244,8 @@ func (c *RolesAnywhereCmd) extractCertificateData() (*rolesAnywhereSignerData, e
 	// Collect certificate and any intermediates
 	certificate := certificateChain[0]
 	var intermediates []x509.Certificate
-	if c.IgnoreIntermediates {
-		intermediates = nil
-	} else {
-		if len(certificateChain) > 1 {
-			intermediates = certificateChain[1:]
-		}
+	if len(certificateChain) > 1 {
+		intermediates = certificateChain[1:]
 	}
 
 	//extract key type

--- a/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
+++ b/cmd/spiffe-aws-assume-role/cli/rolesanywhere_cmd.go
@@ -324,7 +324,7 @@ func (c *RolesAnywhereCmd) createRolesAnywhereCreds(input rolesanywhereCreateCre
 	}
 
 	// Make sure we got temp creds from AWS
-	if len(output.CredentialSet) == 0 {
+	if len(output.CredentialSet) == 0 || output.CredentialSet[0].Credentials == nil {
 		return nil, fmt.Errorf("unable to obtain temporary security credentials from CreateSession")
 	}
 	rolesAnywhereCredentials := output.CredentialSet[0].Credentials


### PR DESCRIPTION
Found a nil deref when I failed to properly configure with an endpoint in use. Added a check in case the creds pointer in the credential set was nil.