### PR TITLE
Pin Github Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go 1.19
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639  # https://github.com/actions/setup-go/releases/tag/v4
         with:
           go-version: '1.19'
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2 https://github.com/actions/checkout/releases/tag/v2
 
       - name: Lint code
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc  # v3 https://github.com/golangci/golangci-lint-action/releases/tag/v3
         with:
           version: v1.52.2
 


### PR DESCRIPTION
Pinning our Github Action dependencies to protect against Software Supply Chain Attacks